### PR TITLE
[FEAT] watch 앱을 위한 뷰 추가

### DIFF
--- a/Mentory/MentoryWatch Watch App/ActionTodoView.swift
+++ b/Mentory/MentoryWatch Watch App/ActionTodoView.swift
@@ -1,0 +1,50 @@
+//
+//  ActionTodoView.swift
+//  MentoryWatch Watch App
+//
+//  Created by 구현모 on 11/19/25.
+//
+
+import SwiftUI
+
+struct ActionTodoView: View {
+    @State private var todoItems = [
+        TodoItem(text: "산책하기", isCompleted: false),
+        TodoItem(text: "물 마시기", isCompleted: true),
+        TodoItem(text: "스트레칭", isCompleted: false)
+    ]
+
+    var body: some View {
+        List {
+            Section {
+                ForEach($todoItems) { $item in
+                    HStack {
+                        Button(action: {
+                            item.isCompleted.toggle()
+                        }) {
+                            Image(systemName: item.isCompleted ? "checkmark.circle.fill" : "circle")
+                                .foregroundColor(item.isCompleted ? .green : .gray)
+                        }
+                        .buttonStyle(.plain)
+
+                        Text(item.text)
+                            .strikethrough(item.isCompleted)
+                            .foregroundColor(item.isCompleted ? .gray : .primary)
+                    }
+                }
+            } header: {
+                Text("오늘의 행동 추천")
+            }
+        }
+    }
+}
+
+struct TodoItem: Identifiable {
+    let id = UUID()
+    var text: String
+    var isCompleted: Bool
+}
+
+#Preview {
+    ActionTodoView()
+}

--- a/Mentory/MentoryWatch Watch App/ContentView.swift
+++ b/Mentory/MentoryWatch Watch App/ContentView.swift
@@ -9,13 +9,25 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        TabView {
+            // 탭 1: 오늘의 명언
+            TodayStringView()
+                .tabItem {
+                    Label("명언", systemImage: "quote.bubble")
+                }
+
+            // 탭 2: 행동 추천 투두
+            ActionTodoView()
+                .tabItem {
+                    Label("투두", systemImage: "checklist")
+                }
+
+            // 탭 3: 음성 기록
+            VoiceRecordView()
+                .tabItem {
+                    Label("기록", systemImage: "mic")
+                }
         }
-        .padding()
     }
 }
 

--- a/Mentory/MentoryWatch Watch App/TodayStringView.swift
+++ b/Mentory/MentoryWatch Watch App/TodayStringView.swift
@@ -1,0 +1,35 @@
+//
+//  TodayStringView.swift
+//  MentoryWatch Watch App
+//
+//  Created by 구현모 on 11/19/25.
+//
+
+import SwiftUI
+
+struct TodayStringView: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                // 아이콘
+                Image(systemName: "quote.bubble.fill")
+                    .font(.system(size: 40))
+                    .foregroundColor(.blue)
+
+                // 제목
+                Text("오늘의 명언")
+                    .font(.headline)
+
+                // 명언 내용 (임시)
+                Text("노력은 배신하지 않는다")
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .padding()
+            }
+        }
+    }
+}
+
+#Preview {
+    TodayStringView()
+}

--- a/Mentory/MentoryWatch Watch App/VoiceRecordView.swift
+++ b/Mentory/MentoryWatch Watch App/VoiceRecordView.swift
@@ -1,0 +1,50 @@
+//
+//  VoiceRecordView.swift
+//  MentoryWatch Watch App
+//
+//  Created by 구현모 on 11/19/25.
+//
+
+import SwiftUI
+
+struct VoiceRecordView: View {
+    @State private var isRecording = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            // 녹음 아이콘
+            ZStack {
+                Circle()
+                    .fill(isRecording ? Color.red.opacity(0.2) : Color.gray.opacity(0.2))
+                    .frame(width: 80, height: 80)
+
+                Image(systemName: isRecording ? "mic.fill" : "mic")
+                    .font(.system(size: 40))
+                    .foregroundColor(isRecording ? .red : .gray)
+            }
+
+            // 녹음 버튼
+            Button(action: {
+                isRecording.toggle()
+            }) {
+                Text(isRecording ? "녹음 중지" : "녹음 시작")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .padding()
+                    .background(isRecording ? Color.red : Color.blue)
+                    .cornerRadius(10)
+            }
+            .buttonStyle(.plain)
+
+            if isRecording {
+                Text("녹음 중...")
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+        }
+    }
+}
+
+#Preview {
+    VoiceRecordView()
+}


### PR DESCRIPTION
### 🔧 변경 사항

#### 새로 추가된 파일
- **TodayStringView.swift** (35줄)
  - 오늘의 명언을 표시하는 뷰
  - ScrollView 기반의 레이아웃
  - 아이콘, 제목, 명언 내용 포함
  
- **ActionTodoView.swift** (50줄)
  - 행동 추천 투두 리스트 뷰
  - 체크박스 토글 기능
  - 완료 시 취소선 및 색상 변경 효과
  - `TodoItem` 모델 구조체 포함
  
- **VoiceRecordView.swift** (50줄)
  - 음성 녹음 UI 뷰
  - 녹음 상태 시각화 (아이콘, 색상 변경)
  - 녹음 시작/중지 버튼
  - 녹음 중 상태 표시

#### 수정된 파일
- **ContentView.swift** (+24 -6)
  - TabView로 3개의 뷰 통합
  - 탭 1: 명언 (TodayStringView)
  - 탭 2: 투두 (ActionTodoView)
  - 탭 3: 기록 (VoiceRecordView)

### ✅ 주요 기능
1. **오늘의 명언 탭**: 명언 표시 (현재 임시 데이터)
2. **행동 추천 투두 탭**: 인터랙티브한 투두 리스트
3. **음성 기록 탭**: 녹음 UI (현재 UI만 구현)
4. **탭 네비게이션**: TabView를 통한 3개 화면 전환

### 스크린샷
<img width="368" height="448" alt="Simulator Screenshot - Apple Watch SE 3 (44mm) - 2025-11-19 at 16 14 19" src="https://github.com/user-attachments/assets/8ace3fc2-c9dc-4596-a166-712dfd36e8f5" />
<img width="368" height="448" alt="Simulator Screenshot - Apple Watch SE 3 (44mm) - 2025-11-19 at 16 14 22" src="https://github.com/user-attachments/assets/4abbfae0-ea80-4a6b-a9f3-66a5ced9207d" />
<img width="368" height="448" alt="Simulator Screenshot - Apple Watch SE 3 (44mm) - 2025-11-19 at 16 14 24" src="https://github.com/user-attachments/assets/0abd6896-f107-4656-b834-84bc15bce0b7" />
<img width="368" height="448" alt="Simulator Screenshot - Apple Watch SE 3 (44mm) - 2025-11-19 at 16 14 28" src="https://github.com/user-attachments/assets/05ceb8c4-20d5-4808-8f1d-1013e7c081b4" />
