### PR TITLE
[FIX] MentorMessage 및 MindAnalyzerView: Watch로 메시지 및 투두 전송 기능 추가

### DIFF
--- a/Mentory/Mentory/Domain/TodayBoard/MentorMessage/MentorMessage.swift
+++ b/Mentory/Mentory/Domain/TodayBoard/MentorMessage/MentorMessage.swift
@@ -130,6 +130,13 @@ final class MentorMessage: Sendable, ObservableObject {
         self.content = messageContent
         self.character = messageCharacter
         self.recentUpdate = .now
+
+        // Watch로 멘토 메시지 전송
+        await WatchConnectivityManager.shared.updateMentorMessage(
+            messageContent,
+            character: messageCharacter.rawValue
+        )
+        logger.debug("Watch로 멘토 메시지 전송: \(messageCharacter.rawValue)")
     }
     
     // MARK: value

--- a/Mentory/Mentory/Presentation/TodayBoard/RecordContainer/MindAnalyzerView/MindAnalyzerView.swift
+++ b/Mentory/Mentory/Presentation/TodayBoard/RecordContainer/MindAnalyzerView/MindAnalyzerView.swift
@@ -139,11 +139,18 @@ struct MindAnalyzerView: View {
                     label: "확인",
                     isPresented: mindAnalyzer.isAnalyzeFinished
                 ) {
-                    let recordForm = mindAnalyzer.owner!
-                    //recordForm.removeForm()
-                    recordForm.finish()
-                    mindAnalyzer.finish()
-                    parentDismiss()
+                    Task {
+                        let recordForm = mindAnalyzer.owner!
+                        let todayBoard = recordForm.owner!
+
+                        // Watch로 투두 전송
+                        await todayBoard.sendSuggestionsToWatch()
+
+                        //recordForm.removeForm()
+                        recordForm.finish()
+                        mindAnalyzer.finish()
+                        parentDismiss()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## About this PR

### 🔗 Related Issue
<!--
- 꼭 "Closes #123" 형태로 적어주세요. (GitHub가 자동으로 이슈와 PR을 연결하고, 머지 시 이슈를 자동으로 닫아줍니다.)
- 여러 개면 아래처럼 적어도 됩니다.
  - Closes #123
  - Related to #124
-->
- X

---

### 📦 Contents
<!--
이 PR에서 무엇을 했는지 **요약**으로 적어주세요.
가능하면 bullet로 정리하면 리뷰어가 보기에 좋습니다.
-->

- 멘토 메시지를 받는 시점과 분석 완료 버튼을 누르는 시점에 워치로 데이터를 보내는 기능 추가
